### PR TITLE
Fix a bug where KeyMan did not work anymore after locking and unlocking Gnome

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -10,28 +10,31 @@ const Gettext = imports.gettext;
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 const KeyMan = Me.imports.keyman.KeyMan;
-//const Utils = Me.imports.utils;
-//const mySettings = Utils.getSettings();
 
 const _ = Gettext.domain('keyman').gettext;
 
-let keyman;    // KeyManager instance
+let keyman;
+
+let initialized = false;
 
 // Init function
 function init(metadata) {
     // Read locale files
     let locales = Me.dir.get_path() + "/locale";
     Gettext.bindtextdomain('keyman', locales);
+    keyman = new KeyMan();
 }
 
 function enable() {
-    keyman = new KeyMan();
     keyman._enable();
-    Main.panel.addToStatusArea('keyman', keyman.theButton);
+    if (!initialized) {
+        Main.panel.addToStatusArea('keyman', keyman.theButton);
+        initialized = true;
+    } else {
+        keyman._reconnect();
+    }
 }
 
 function disable() {
     keyman._disable();
-    keyman.destroy();
-    keyman = null;
 }

--- a/keyman.js
+++ b/keyman.js
@@ -314,4 +314,8 @@ class KeyMan {
         this._removeTimeouts();
         this.history.close();
     }
+
+    _reconnect() {
+        this.keyring = new KeyringConnection();
+    }
 }


### PR DESCRIPTION
The connection with the session was lost. By creating a new connection
after unlocking everything works as intended.